### PR TITLE
#164121031 fix a bug in reset password link

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -158,7 +158,7 @@ class ResetPasswordAPIView(generics.CreateAPIView):
         user = models.User.objects.filter(email=email)
         if user:
             token = jwt.encode({"email": email, "iat": datetime.now(),
-                                "exp": datetime.utcnow() + timedelta(minutes=5)},
+                                "exp": datetime.utcnow() + timedelta(minutes=60)},
                                settings.SECRET_KEY, algorithm='HS256').decode()
             to_email = [email]
             DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")


### PR DESCRIPTION
**The Reset password link expires after 5 mins.**

**Description**

**What is currently happening?**
A user gets a link in their email that allows them to change their password. The link expires after 5 mins.

**What should be happening?**
The link should expire after 1 hour to give the user sufficient time to update the password.
[#164121031](https://www.pivotaltracker.com/story/show/164121031)