### PR TITLE
#164187822 Implement fix for image uploads for articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -12,7 +12,7 @@ class Article(models.Model):
     title = models.CharField(max_length=200, blank=True)
     body = models.TextField(blank=True)
     description = models.CharField(max_length=50, blank=True)
-    images = CloudinaryField(blank=True, default='No image', null=True)
+    images = models.URLField(blank=True, default='https://cdn0.iconfinder.com/data/icons/mtt-web-icons/139/article-512.png')
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     slug = models.SlugField(max_length=50, blank=False, unique=True)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -12,7 +12,7 @@ class ArticleSerializer(TaggitSerializer, serializers.ModelSerializer):
     # Field in the database corresponding to the User model
     author = serializers.SerializerMethodField()
     # Uploads an image to the Cloudinary servers
-    images = serializers.ImageField(default=None)
+    images = serializers.URLField(required=False)
     tagList = TagListSerializerField()
     user_id_likes = serializers.PrimaryKeyRelatedField(
         many=True, read_only=True)


### PR DESCRIPTION
**What does this PR do?**
Fixes the Image field so that it accepts image URL field

**Description of tasks to be completed**

* Change the Cloudinary  field to image field in `authors/apps/articles/models.py`
* Change the Image serializer to URL serializer in `authors/apps/articles/serializers.py`

**How should this be manually tested?**
Clone this repo `git clone https://github.com/andela/ah-django-unchained.git`

`cd ah-django-unchained`

`git checkout bg-fix-upload-images-articles-164187822`

`set the environment variable as stated in the read me and run python manage.py test.`

**Relevant Pivotal Tracker Story**
[#164187822](https://www.pivotaltracker.com/story/show/164187822)